### PR TITLE
fix: use N instead of deprecated n in frollapply calls

### DIFF
--- a/R/find_do_noise.R
+++ b/R/find_do_noise.R
@@ -47,8 +47,8 @@ find_do_noise <- function(df){
       # Create binary indicator for DO interference flag
       dplyr::mutate(DO_drift_binary = ifelse(grepl("DO interference", flag), 1, 0)) %>%
       # Apply rolling window check in both right-aligned and center-aligned modes
-      dplyr::mutate(right = data.table::frollapply(DO_drift_binary, n = 96, FUN = check_day_hour_window_fail, align = "right", fill = NA),
-                    center = data.table::frollapply(DO_drift_binary, n = 96, FUN = check_day_hour_window_fail, align = "center", fill = NA)) %>%
+      dplyr::mutate(right = data.table::frollapply(DO_drift_binary, N = 96, FUN = check_day_hour_window_fail, align = "right", fill = NA),
+                    center = data.table::frollapply(DO_drift_binary, N = 96, FUN = check_day_hour_window_fail, align = "center", fill = NA)) %>%
       # Flag possible burial if either window check indicates persistent interference
       add_flag(right == 1 | center == 1, "Possible burial") %>% 
       select(-c(DO_drift_binary, right, center))

--- a/R/low_pass_filter.R
+++ b/R/low_pass_filter.R
@@ -49,17 +49,17 @@ low_pass_filter <- function(df) {
       mutate(
         # First pass
         smoothed_mean = if_else(is.na(smoothed_mean), 
-                                data.table::frollapply(mean, n = 5, FUN = binomial_kernel, 
+                                data.table::frollapply(mean, N = 5, FUN = binomial_kernel, 
                                                        fill = NA, align = "center"),
                                 smoothed_mean),
         # Second pass
         smoothed_mean = if_else(is.na(smoothed_mean), 
-                                data.table::frollapply(smoothed_mean, n = 5, FUN = binomial_kernel, 
+                                data.table::frollapply(smoothed_mean, N = 5, FUN = binomial_kernel, 
                                                        fill = NA, align = "center"),
                                 smoothed_mean),
         # Third pass
         smoothed_mean = if_else(is.na(smoothed_mean), 
-                                data.table::frollapply(smoothed_mean, n = 5, FUN = binomial_kernel, 
+                                data.table::frollapply(smoothed_mean, N = 5, FUN = binomial_kernel, 
                                                        fill = NA, align = "center"),
                                 smoothed_mean)
       )


### PR DESCRIPTION
## Problem

data.table::frollapply() deprecated the `n` parameter in favor of `N`. All 5 calls in this package use the deprecated form, which produces warnings.

Closes #29

## Changes

- R/low_pass_filter.R: Updated 3 frollapply calls from n=5 to N=5
- R/find_do_noise.R: Updated 2 frollapply calls from n=96 to N=96

## Validation

- Both R files parse successfully with parse()
- No other files reference frollapply
- Change is purely mechanical (parameter rename, no logic change)